### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,16 @@
         <version>2.1.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
+    <repositories>
+    <repository>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+        <id>jcenter-releases</id>
+        <name>jcenter</name>
+        <url>http://jcenter.bintray.com</url>
+    </repository>
+    </repositories>
     <groupId>com.xinghua</groupId>
     <artifactId>elasticsearch-service</artifactId>
     <version>1.0.0</version>


### PR DESCRIPTION
ch.netzwerg:paleo-core:0.10.2包依赖问题　markdown_to_asciidoc不能用了，被Spring Plugins Repository代替了。　更新了pom文件